### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bluetoothctl
+hcitool
+l2ping


### PR DESCRIPTION
Add the necessities into a file named requirements.txt so that people can use '''pip3 install -r requirements.txt''' to install the requirements directly. 